### PR TITLE
Mask runner skip processing if output file exists

### DIFF
--- a/docs/source/pipeline_canfar.md
+++ b/docs/source/pipeline_canfar.md
@@ -53,6 +53,10 @@ job_sp_canfar.bash -p $psf -n $N_SMP -j 2
 # Mask tiles
 job_sp_canfar.bash -p $psf -n $N_SMP -j 4
 
+# If not finshed:
+combine_runs.bash -p psfex -c flag
+mv output/run_sp_combined_flag output/run_sp_exp_Ma
+
 # Mask exposures
 job_sp_canfar.bash -p $psf -n $N_SMP -j 8
 

--- a/example/cfis/config_tile_Sx.ini
+++ b/example/cfis/config_tile_Sx.ini
@@ -55,7 +55,7 @@ TIMEOUT = 96:00:00
 
 [SEXTRACTOR_RUNNER]
 
-INPUT_DIR = last:get_images_runner_run_1, last:uncompress_fits_runner, run_sp_tile_Ma:mask_runner
+INPUT_DIR = last:get_images_runner_run_1, last:uncompress_fits_runner, run_sp_Ma_tile:mask_runner
 
 FILE_PATTERN = CFIS_image, CFIS_weight, pipeline_flag
 

--- a/scripts/sh/combine_runs.bash
+++ b/scripts/sh/combine_runs.bash
@@ -17,9 +17,10 @@ usage="Usage: $(basename "$0") [OPTIONS]
 \n\nOptions:\n
    -h\tthis message\n
    -p, --psf MODEL\n
-    \tPSF model, one in ['psfex'|'mccd'|'setools'], default='$psf'\n
+    \tPSF model, allowed are 'psfex', 'mccd', 'setools', default='$psf'\n
    -c, --cat TYPE\n
-    \tCatalogue type, one in ['final'|'flag'|'psf'|'image'], default='$cat'\n
+    \tCatalogue type, allowed are 'final', 'flag_tile', 'flag_exp', \n
+    \t'psf', 'image', default='$cat'\n
 "
 
 ## Parse command line
@@ -48,10 +49,11 @@ done
 
 ## Check options
 if [ "$cat" != "final" ] \
-  && [ "$cat" != "flag" ] \
+  && [ "$cat" != "flag_tile" ] \
+  && [ "$cat" != "flag_exp" ] \
   && [ "$cat" != "psf" ] \
   && [ "$cat" != "image" ]; then
-  echo "cat (option -c) needs to be 'final', 'flag', 'psf', or 'image'"
+  echo "cat (option -c) needs to be 'final', 'flag_tile', 'flag_exp', 'psf', or 'image'"
   exit 2
 fi
 
@@ -106,11 +108,27 @@ if [ "$cat" == "final" ]; then
   module="make_catalog_runner"
   pattern="final_cat-*"
 
-elif [ "$cat" == "flag" ]; then
+elif [ "$cat" == "flag_tile" ]; then
 
-  run_in="$pwd/$out_base/run_sp_MaMa_*/mask_runner_run_1"
-  module="mask_runner_run_1"
-  pattenr="pipeline_flag-*"
+  # v1
+  #run_in="$pwd/$out_base/run_sp_MaMa_*/mask_runner_run_1"
+  # v2
+  run_in="$pwd/$out_base/run_sp_tile_Ma_*"
+  run_out="run_sp_tile_Ma"
+
+  module="mask_runner"
+  pattern="pipeline_flag-*"
+
+elif [ "$cat" == "flag_exp" ]; then
+
+  # v1
+  #run_in="$pwd/$out_base/run_sp_MaMa_*/mask_runner_run_2"
+  # v2
+  run_in="$pwd/$out_base/run_sp_exp_Ma_*"
+  run_out="run_sp_exp_Ma"
+
+  module="mask_runner"
+  pattern="pipeline_flag-*"
 
 elif [ "$cat" == "image" ]; then
 
@@ -162,13 +180,15 @@ i=0
 for dir in $run_in; do
   FILES=(`find $dir -type f -name "$pattern" -print0 | xargs -0 echo`)
 
+  echo "$dir $pattern"
+
   ## Look over source files
   for file in ${FILES[@]}; do
 
-  target=$file
-  link_name=$outdir/`basename $file`
-  link_s $target $link_name
-  ((i=i+1))
+    target=$file
+    link_name=$outdir/`basename $file`
+    link_s $target $link_name
+    ((i=i+1))
 
   done
 

--- a/scripts/sh/combine_runs.bash
+++ b/scripts/sh/combine_runs.bash
@@ -114,7 +114,7 @@ elif [ "$cat" == "flag_tile" ]; then
   #run_in="$pwd/$out_base/run_sp_MaMa_*/mask_runner_run_1"
   # v2
   run_in="$pwd/$out_base/run_sp_tile_Ma_*"
-  run_out="run_sp_tile_Ma"
+  run_out="run_sp_Ma_tile"
 
   module="mask_runner"
   pattern="pipeline_flag-*"
@@ -125,7 +125,7 @@ elif [ "$cat" == "flag_exp" ]; then
   #run_in="$pwd/$out_base/run_sp_MaMa_*/mask_runner_run_2"
   # v2
   run_in="$pwd/$out_base/run_sp_exp_Ma_*"
-  run_out="run_sp_exp_Ma"
+  run_out="run_sp_Ma_exp"
 
   module="mask_runner"
   pattern="pipeline_flag-*"

--- a/scripts/sh/curl_canfar_local.sh
+++ b/scripts/sh/curl_canfar_local.sh
@@ -205,7 +205,6 @@ else
       echo "Split '$file_IDs' into $n_split batches of size $batch"
 
       count=1
-      #n_running=`stats_headless_canfar.py`
       n_running=`stats_jobs_canfar.sh`
       for batch in $prefix*; do
         echo "Number of running jobs = $n_running"

--- a/scripts/sh/curl_canfar_local.sh
+++ b/scripts/sh/curl_canfar_local.sh
@@ -214,13 +214,11 @@ else
         submit_batch $batch
         ((count=count+1))
 
-        #n_running=`stats_headless_canfar.py`
         n_running=`stats_jobs_canfar.sh`
 
         while [ "$n_running" -gt "$n_thresh" ]; do
           echo "Wait for #jobs = $n_running jobs to go < $n_thresh ..."
           sleep $sleep
-          #n_running=`stats_headless_canfar.py`
           n_running=`stats_jobs_canfar.sh`
         done
 

--- a/shapepipe/modules/mask_package/__init__.py
+++ b/shapepipe/modules/mask_package/__init__.py
@@ -63,6 +63,9 @@ PREFIX : str, optional
     Prefix to be appended to output file name ``flag``;
     helps to distinguish the file patterns of newly created and external
     mask files
+CHECK_EXISTING_DIR : str, optional
+    If given, search this directory for existing mask files; the
+    corresponding images will then not be processed
 
 Mask config file
 ================

--- a/shapepipe/modules/mask_package/mask.py
+++ b/shapepipe/modules/mask_package/mask.py
@@ -102,7 +102,7 @@ class Mask(object):
         self._outname_base = outname_base
 
         # Search path for existing mask files
-        self._check_existing_dir= check_existing_dir
+        self._check_existing_dir = check_existing_dir
 
         # Set external star catalogue path if given
         if star_cat_path is not None:

--- a/shapepipe/modules/mask_package/mask.py
+++ b/shapepipe/modules/mask_package/mask.py
@@ -45,6 +45,8 @@ class Mask(object):
         Path to external flag file, default is ``None`` (not used)
     outname_base : str, optional
        Output file name base, default is ``flag``
+    check_existing_dir : str, optional
+        If not ``None`` (default), search path for existing mask files
     star_cat_path : str, optional
         Path to external star catalogue, default is ``None`` (not used;
         instead the star catalogue is produced on the fly at run time)
@@ -64,6 +66,7 @@ class Mask(object):
         w_log,
         path_external_flag=None,
         outname_base='flag',
+        check_existing_dir=None,
         star_cat_path=None,
         hdu=0,
     ):
@@ -97,6 +100,9 @@ class Mask(object):
 
         # Output file base name
         self._outname_base = outname_base
+
+        # Search path for existing mask files
+        self._check_existing_dir= check_existing_dir
 
         # Set external star catalogue path if given
         if star_cat_path is not None:
@@ -308,6 +314,16 @@ class Mask(object):
         Main function to create the mask.
 
         """
+        output_file_name = (
+            f'{self._img_prefix}'
+            + f'{self._outname_base}{self._img_number}.fits'
+        )
+        if (
+            os.path.exists(f"{self._check_existing_dir}//{output_file_name}")
+        ):
+            print("MKDEBUG skipping ", output_file_name)
+            return None, None
+
         if self._config['MD']['make']:
             self.missing_data()
 

--- a/shapepipe/modules/mask_runner.py
+++ b/shapepipe/modules/mask_runner.py
@@ -91,6 +91,15 @@ def mask_runner(
 
     outname_base = 'flag'
 
+    # Path to check for already created mask files
+    if config.has_option(module_config_sec, 'CHECK_EXISTING_DIR'):
+        check_existing_dir = config.getexpanded(
+            module_config_sec,
+            'CHECK_EXISTING_DIR'
+        )
+    else:
+        check_existing_dir = None
+
     # Create instance of Mask
     mask_inst = Mask(
         *input_file_list[:2],
@@ -101,6 +110,7 @@ def mask_runner(
         path_external_flag=ext_flag_name,
         outname_base=outname_base,
         star_cat_path=ext_star_cat,
+        check_existing_dir=check_existing_dir,
         hdu=hdu,
         w_log=w_log,
     )

--- a/shapepipe/modules/merge_sep_cats_package/merge_sep_cats.py
+++ b/shapepipe/modules/merge_sep_cats_package/merge_sep_cats.py
@@ -87,6 +87,12 @@ class MergeSep(object):
             cat0.open()
             list_ext_name = cat0.get_ext_name()
             list_col_name = cat0.get_col_names()
+            # MKDEBUG: Some input ngmix catalogues have multiple of 5 HDUs
+            # if reprocessed and not deleted but appended
+            if len(list_ext_name) > 6:
+                wmsg = f"Cropping input HDUs from {len(list_ext_name)} to 5"
+                self._w_log.info(wmsg)
+                list_ext_name = list_ext_name[:6]
             cat0.close()
 
             # Create empty dictionary

--- a/shapepipe/utilities/summary.py
+++ b/shapepipe/utilities/summary.py
@@ -431,7 +431,8 @@ class job_data(object):
             self.write_IDs_to_file(output_path, missing_IDs_all)
         else:
             #logging.warning("no missing IDs in output_missing_job")
-            os.unlink(output_path)
+            if os.path.exists(output_path):
+                os.unlink(output_path)
 
     @classmethod
     def get_last_full_path(self, base_and_subdir, matches):

--- a/shapepipe/utilities/summary.py
+++ b/shapepipe/utilities/summary.py
@@ -430,7 +430,8 @@ class job_data(object):
         if len(missing_IDs_all) > 0:
             self.write_IDs_to_file(output_path, missing_IDs_all)
         else:
-            logging.warning("no missing IDs in output_missing_job")
+            #logging.warning("no missing IDs in output_missing_job")
+            os.unlink(output_path)
 
     @classmethod
     def get_last_full_path(self, base_and_subdir, matches):
@@ -648,8 +649,8 @@ class job_data(object):
                 self._missing_IDs_job.extend(missing_IDs)
 
         # Write missing IDs for entire job to file
-        if n_missing_job > 0:
-            self.output_missing_job()
+        #if n_missing_job > 0:
+        self.output_missing_job()
 
 
 def get_par_runtime(par_runtime, key, kind="n"):


### PR DESCRIPTION
Added config entry CHECK_EXISTING_DIR to mask runner. The corresponding string, if present, is the directory in which existing, processed mask files will be searched. If an output file exists, processing is skipped.
