### PR TITLE
Shapepipe with automatic Docker builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,42 +3,49 @@ name: Deploy API Docs
 on:
   push:
     branches:
-     - master
-     - main
+     - v1.4_docker
 
 jobs:
 
-  api:
-    name: Deploy API Documentation
-    runs-on: ubuntu-latest
+  test-full:
+    name: Full Test Suite
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.8]
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install libopenblas-dev
+
+      - name: Install macOS Dependencies
+        shell: bash -l {0}
+        if: runner.os == 'macOS'
+        run: |
+          brew tap sfarrens/sf
+          brew install bigmac libomp
 
       - name: Set up conda
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
           auto-activate-base: true
 
-      - name: Install dependencies
+      - name: Install package
         shell: bash -l {0}
         run: |
-          ./install_shapepipe --develop --no-exe --no-mpi
-          conda activate shapepipe
-          python -m pip install --upgrade importlib-metadata
-          conda install -c conda-forge pandoc
+          ./install_shapepipe --env-dev --develop
 
-      - name: Build API documentation
+      - name: Run tests
         shell: bash -l {0}
         run: |
-          conda activate shapepipe
-          sphinx-apidoc -t docs/_templates -feTMo docs/source shapepipe shapepipe/modules/*_runner.py
-          sphinx-build -E docs/source docs/_build
-
-      - name: Deploy API documentation
-        uses: peaceiris/actions-gh-pages@v3.5.9
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/_build
+          conda activate shapepipe-dev
+          python setup.py test
+          shapepipe_run -c example/config.ini

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,8 @@ name: Deploy API Docs
 on:
   push:
     branches:
-     - v1.4_docker
+     - master
+     - main
 
 jobs:
 

--- a/.github/workflows/deploy-image.bak.yml
+++ b/.github/workflows/deploy-image.bak.yml
@@ -1,0 +1,41 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['master']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action
+        uses: docker/metadata-action@master
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -10,7 +10,9 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: 
+      - ubuntu-latest
+      - macos-latest
     permissions:
       contents: read
       packages: write
@@ -20,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -28,12 +30,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action
         with:
           context: .
           push: true

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,16 +1,41 @@
-name: Docker Image CI
+name: Create and publish a Docker image
 
 on:
   push:
-    branches: [ "v1.4_docker" ]
+    branches: ['v1.4_docker']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-
-  build:
-
+  build-and-push-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag shapepipe:v1.4
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -12,17 +12,14 @@ jobs:
   build-and-push-image:
     runs-on: 
       - ubuntu-latest
-      - macos-latest
+      # - macos-latest
     permissions:
       contents: read
       packages: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@master
-
       - name: Log in to the Container registry
-        uses: docker/login-action@master
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -30,12 +27,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@master
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@master
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@master
 
       - name: Log in to the Container registry
-        uses: docker/login-action
+        uses: docker/login-action@master
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -35,7 +35,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action
+        uses: docker/build-push-action@master
         with:
           context: .
           push: true

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,41 +1,16 @@
-name: Create and publish a Docker image
+name: Docker Image CI
 
 on:
   push:
-    branches: ['master']
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+    branches: [ "v1.4_docker" ]
 
 jobs:
-  build-and-push-image:
+
+  build:
+
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag shapepipe:v1.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir \
     astropy==5.2 \
     cs_util==0.1.0 \
-    galsim==2.2.5 \
+    galsim==2.2.6 \
     ipython==8.18.1 \
     joblib==1.1.0 \
     jupyterlab==4.3.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir \
     astropy==5.2 \
     cs_util==0.1.0 \
-    galsim==2.6.1 \
+    galsim==2.2.5 \
     ipython==8.18.1 \
     joblib==1.1.0 \
     jupyterlab==4.3.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,8 @@ RUN pip install --no-cache-dir --upgrade pip && \
     numpy==1.26.4 \
     numpydoc==1.2  \
     pandas==1.4.1  \
+    PyQt5==5.15.6 \
+    pyqtgraph==0.12.4 \
     pytest==8.3.3 \
     pytest-cov==5.0.0 \
     pytest-pycodestyle==2.4.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,57 +1,101 @@
-FROM continuumio/miniconda3
+FROM python:3.9-bookworm
 
-LABEL Description="ShapePipe Docker Image"
-ENV SHELL /bin/bash
+LABEL Description="Conda-Free ShapePipe Docker Image"
+ENV SHELL=/bin/bash
 
-ARG CC=gcc-9
-ARG CXX=g++-9
+# Install system dependencies
+RUN apt-get update -y --quiet --fix-missing && \
+    apt-get dist-upgrade -y --quiet --fix-missing && \
+    apt-cache policy autconf && \ 
+    apt-get install -y --quiet \
+    apt-utils \
+    autoconf \
+    automake \
+    build-essential \
+    cmake \
+    curl \
+    ffmpeg \
+    g++ \
+    gcc  \
+    gfortran \
+    git-lfs \
+    libatlas-base-dev \
+    libblas-dev \
+    liblapack-dev \
+    libcfitsio-dev \
+    libfftw3-bin \
+    libfftw3-dev \
+    libgl1-mesa-glx \
+    libtool \
+    libtool-bin \
+    libtool-doc \
+    locales \
+    locate \
+    make \
+    openmpi-bin \
+    libopenmpi-dev \
+    pkg-config \
+    protobuf-compiler \
+    psfex=3.21.1-1 \
+    sextractor=2.25.0+ds-3 \
+    weightwatcher=1.12+dfsg-3 \
+    vim \
+    xterm && \
+    apt-get clean -y && \
+    apt-get autoremove --purge --quiet -y && \
+    rm -rf /var/lib/apt/lists/* /var/tmp/*
 
-# gcc < 10 is required to compile ww
-ENV CC=gcc-9
-ENV CXX=g++-9
+# Install CDS client by hand
+RUN cd /tmp && \
+    curl -O http://cdsarc.u-strasbg.fr/ftp/pub/sw/cdsclient.tar.gz && \
+    tar xvfz cdsclient.tar.gz \ 
+    && cd cdsclient-* \
+    && ./configure && make && make install \
+    && rm -rf /tmp/*
 
-RUN apt-get update --allow-releaseinfo-change && \
-    apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install apt-utils -y && \
-    apt-get install make -y && \
-    apt-get install automake -y && \
-    apt-get install autoconf -y && \
-    apt-get install gcc-9 g++-9 -y && \
-    apt-get install gfortran -y && \
-    apt-get install locales -y && \
-    apt-get install libgl1-mesa-glx -y && \
-    apt-get install xterm -y && \
-    apt-get install cmake protobuf-compiler -y && \
-    apt-get install libtool libtool-bin libtool-doc -y && \
-    apt-get install libfftw3-bin libfftw3-dev -y && \
-    apt-get install libatlas-base-dev liblapack-dev libblas-dev -y && \
-    apt-get install vim -y && \
-    apt-get install locate -y && \
-    apt-get install curl -y && \
-    apt-get install acl -y && \
-    apt-get install sssd -y && \
-    apt-get clean
+# Install python dependencies
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir \
+    astropy==5.2 \
+    cs_util==0.1.0 \
+    galsim==2.6.1 \
+    ipython==8.18.1 \
+    joblib==1.1.0 \
+    jupyterlab==4.3.1 \
+    matplotlib==3.8.4 \
+    mccd==1.2.4 \
+    modopt==1.6.1 \
+    mpi4py==3.1.3 \
+    numba==0.58.1 \
+    numpy==1.26.4 \
+    numpydoc==1.2  \
+    pandas==1.4.1  \
+    pytest==8.3.3 \
+    pytest-cov==5.0.0 \
+    pytest-pycodestyle==2.4.1 \
+    pytest-pydocstyle==2.4.0 \
+    python-pysap==0.2.1 \
+    reproject==0.8 \
+    sf_tools==2.0.4 \
+    sip_tpv==1.1 \
+    skaha==1.4.3 \
+    sqlitedict==2.0.0 \
+    termcolor==1.1.0 \
+    tqdm==4.63.0 \
+    treecorr==4.2.6 \
+    vos==3.6.1.1 \
+    git+https://github.com/aguinot/ngmix@stable_version \
+    git+https://github.com/tobias-liaudat/Stile@v0.1
 
-ADD nsswitch.conf /etc/
 
-RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
-    locale-gen
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+WORKDIR /app
+COPY . /app/.
 
-SHELL ["/bin/bash", "--login", "-c"]
-
-COPY ./environment.yml ./
-COPY install_shapepipe README.rst setup.py setup.cfg ./
-RUN touch ./README.md
-
-RUN conda update -n base -c defaults conda -c defaults
-RUN conda env create --file environment.yml
-
-COPY shapepipe ./shapepipe
-COPY scripts ./scripts
-
-RUN source activate shapepipe
-#RUN pip install jupyter
+# Install shapepipe and symlink scripts
+RUN pip install --no-cache-dir -e . && \ 
+    for ext in .py .sh .bash; do \
+    for script in /app/scripts/*/*$ext; do \
+    link_name=`basename $script $ext`; \
+    ln -s $script /usr/local/bin/$link_name; \
+    done; \
+    done

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update -y --quiet --fix-missing && \
     pkg-config \
     protobuf-compiler \
     psfex=3.21.1-1 \
-    sextractor=2.25.0+ds-3 \
+    source-extractor=2.25.0+ds-3 \
     weightwatcher=1.12+dfsg-3 \
     vim \
     xterm && \

--- a/scripts/python/shapepipe_run.py
+++ b/scripts/python/shapepipe_run.py
@@ -1,4 +1,4 @@
-#!/arc/home/kilbinger/.conda/envs/shapepipe/bin/python
+#!/usr/bin/env python
 
 """SHAPEPIPE RUN SCRIPT
 


### PR DESCRIPTION
## Summary
Updated Dockerfile and added a GitHub action to automatically build the docker container upon commit.

One thing that @fabianhervaspeters noticed is in the `apt-get install`ed version of `sextractor`, the `sex` command has been renamed to `source-extractor` to be more work-appropriate. This means any shapepipe calls will have to be changed.. Fabian wrote a fix, maybe that can be contributed here? I guess we'll have to support both commands in case people aren't using the docker container, and check which one is available on the fly?
